### PR TITLE
Add scaling factor for node locs; Add zoom with - / + keys

### DIFF
--- a/ClickGrid.pde
+++ b/ClickGrid.pde
@@ -1,10 +1,11 @@
-int gridScale = 40;
+float gridScale = 40, minGridScale = 5;
+float mScale = 1/gridScale, zoomInc = 5;
 ArrayList<Node> nodes = new ArrayList<Node>();
 ArrayList<Connector> cons = new ArrayList<Connector>();
 ArrayList<Node> activeNodes = new ArrayList<Node>();
 ArrayList<Connector> activeCons = new ArrayList<Connector>();
-Node dragNode;
-Connector addingCon;
+Node dragNode = null;
+Connector addingCon = null;
 float totLen;
 
 void setup() {
@@ -40,7 +41,7 @@ void draw() {
   textSize(15);
   text("# Nodes: "+nodes.size(), 10, 15);
   text("# Cons:  "+cons.size(), 10, 35);
-  text("length:  "+totLen/gridScale, 10, 55);
+  text("length:  "+totLen, 10, 55);
   //test dispay
   text("active N: "+activeNodes.size(), 10, 75);
   text("active C: "+activeCons.size(), 10, 95);
@@ -124,4 +125,23 @@ void removeCon(Connector c) {
   //if con active, will remove itself from activeCons list
   c.setActive(false);
   cons.remove(c);
+}
+
+void keyPressed() {
+  //Use keys to increment zoom scale
+  //nested if prevents gridScale from reaching zero, or 1/0 for mScale later
+  if (key == '=' || key == '+') rescale(gridScale + zoomInc);
+  else if (key == '-' || key == '_') {
+    if (gridScale > minGridScale) rescale(gridScale - zoomInc);
+  }
+}
+
+void rescale (float newScale) {
+  float sFactor = newScale / gridScale;
+  gridScale = newScale;
+  mScale = 1/gridScale;
+  for (Node n : nodes) {
+    n.setLoc(n.x * sFactor, n.y * sFactor);
+    n.mUpdate();
+  }
 }

--- a/Connector.pde
+++ b/Connector.pde
@@ -63,7 +63,7 @@ class Connector {
   }
 
   void updateLenMid() {
-    len = dist(pq[0].x, pq[0].y, pq[1].x, pq[1].y);
+    len = dist(pq[0].xm, pq[0].ym, pq[1].xm, pq[1].ym);
     float midx = (pq[0].x + pq[1].x)/2;
     float midy = (pq[0].y + pq[1].y)/2;
     midpoint = new PVector(midx, midy);

--- a/Node.pde
+++ b/Node.pde
@@ -1,5 +1,5 @@
 class Node {
-  float x, y;
+  float x, y, xm, ym;
   color col, BASE = color(100, 160, 235), HIGHLIGHT = color(255, 210, 60);
   boolean dragging;
   boolean active;
@@ -7,6 +7,7 @@ class Node {
   Node(float x_, float y_) {
     x = x_;
     y = y_;
+    mUpdate(); //update x,y to xm,ym (aka model coords)
     col = BASE;
     dragging = false;
     active = false;
@@ -17,7 +18,7 @@ class Node {
     noStroke();
     if (active) {
       fill(HIGHLIGHT);
-      text(x+","+y, x+10, y-15);
+      text(xm+","+ym, x+10, y-15);
     } else {
       fill(col);
     }
@@ -45,11 +46,17 @@ class Node {
     if (dragging) {
       x = constrain(mouseX, 0, width);
       y = constrain(mouseY, 0, height);
+      mUpdate();
     }
   }
 
   void setLoc (float x_, float y_) {
     x = x_;
     y = y_;
+  }
+  
+  void mUpdate () {
+    xm = map(x,0,width,0,width*mScale);
+    ym = map(y,0,height,0,height*mScale);
   }
 }


### PR DESCRIPTION
Node: Added attributes xm, ym (x and y in model coordinates). Added mUpdate() method that maps Node x,y (aka screen x,y) to these, per mScale from ClickGrid.
Connector: Changed updateLenMid() to calculate len per Nodes' xm,ym (aka- use model coords, governed by gridScale).
ClickGrid: Added mScale variable to precalculate [1 / gridScale] (since can be used by multiple Nodes as a multiplier).  Added minGridScale to set min, also prevents mScale = 1 / 0. Added keyPressed() to include [-/+] keys for zooming scale. Also calls new rescale() function, which updates gridScale, mScale, and Nodes' x,y,xm,ym. Add zoomInc variable for setting zoom increments. Removed gridScale from totLen calculation, since connectors' len now already calculated per node xm,ym.